### PR TITLE
fixes a bug with salvaging a broke car, reworks it a little

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -47,6 +47,8 @@
 
 // No comment
 /atom/proc/attackby(obj/item/W, mob/user, params)
+	if(linked_attack_parent)
+		linked_attack_parent.attackby(W, user)
 	if(SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, W, user, params) & COMPONENT_NO_AFTERATTACK)
 		return STOP_ATTACK_PROC_CHAIN
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -73,6 +73,9 @@
 	///Mobs that are currently do_after'ing this atom, to be cleared from on Destroy()
 	var/list/targeted_by
 
+	///Linked atom that will be attacked if this atom is attacked. Currently implemented for /structure/car
+	var/atom/linked_attack_parent
+
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation
 	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()

--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -40,7 +40,7 @@
 	density = 1
 	layer = ABOVE_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE
-	var/uses_left = 4
+	var/uses_left = 5 //yea, when it "read" 4, it was 5 still. I've changed some stuff to where it "reads" 5 and actually is 5.
 	var/inuse = FALSE
 	var/S1
 	var/S2
@@ -56,6 +56,7 @@
 	S.anchored = 1
 	S.icon = null
 	S.verbs.Cut()
+	S.linked_attack_parent = src
 
 	S = new (locate(x+1,y+1,z))
 	S2 = S
@@ -63,6 +64,7 @@
 	S.anchored = 1
 	S.icon = null
 	S.verbs.Cut()
+	S.linked_attack_parent = src
 
 	S = new (locate(x,y+1,z))
 	S3 = S
@@ -70,36 +72,43 @@
 	S.anchored = 1
 	S.icon = null
 	S.verbs.Cut()
+	S.linked_attack_parent = src
 
-/obj/structure/car/attackby(obj/item/I, mob/user, params)
+/obj/structure/car/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/weldingtool))
-		if (inuse)
+		if(inuse || uses_left <= 0) //this means that if mappers or admins want an nonharvestable version, set the uses_left to 0
 			return
-		if(!I.tool_start_check(user, amount=0))
-			return
-		user.visible_message("[user] starts to disassemble the wreck.</span>")
-		inuse = TRUE
-		if(I.use_tool(src, user, 300, volume=100))
-			user.visible_message("[user] disassembles the wreck.</span>")
+		inuse = TRUE //one at a time boys, this isn't some kind of weird party
+		if(!I.tool_start_check(user, amount=0)) //this seems to be called everywhere, so for consistency's sake
 			inuse = FALSE
-			new /obj/item/stack/sheet/metal/five/(get_turf(user))
-			if (prob(50))
-				new /obj/item/stack/crafting/goodparts/(get_turf(user))
-			if (prob(50))
-				new /obj/item/stack/crafting/goodparts/(get_turf(user))
-			if (prob(50))
-				new /obj/item/stack/crafting/goodparts/(get_turf(user))
-			new /obj/item/stack/crafting/goodparts/(get_turf(user))
-			if (uses_left == 0)
-				qdel(src)
-				qdel(S1)
-				qdel(S2)
-				qdel(S3)
-				qdel(S4)
-				return
-			else
-				uses_left--
-				return
+			return //the tool fails this check, so stop
+		user.visible_message("[user] starts disassembling [src].")
+		if(!I.use_tool(src, user, 0, volume=100)) //here is the dilemma, use_tool doesn't work like do_after, so moving away screws it(?)
+			inuse = FALSE
+			return //you can't use the tool, so stop
+		for(var/i1 in 1 to 3) //so, I hate waiting 30 seconds straight... what if we wait 10 seconds 3 times? (yes, its the same, but it'll feel more!)
+			if(!do_after(user, 10 SECONDS, target = src)) //this is my work around, because do_After does have a move away
+				user.visible_message("[user] stops disassembling [src].")
+				inuse = FALSE
+				return //you did something, like moving, so stop
+			var/fake_dismantle = pick("plating", "rod", "rim", "part of the frame")
+			user.visible_message("[user] slices through a [fake_dismantle].")
+			I.play_tool_sound(src, 100)
+		var/turf/usr_turf = get_turf(user)
+		for(var/i2 in 1 to rand(3, 7)) //also changing this a little. IDEA: perhaps a mechanic skill could affect the amount dropped instead
+			new /obj/item/stack/sheet/metal(usr_turf)
+		for(var/i3 in 1 to 3) //this is just less lines for the same thing
+			if(prob(50))
+				new /obj/item/stack/crafting/goodparts(usr_turf)
+		uses_left--
+		inuse = FALSE //putting this after the -- because the first check prevents cheesing
+		if(uses_left <= 0) //I prefer to put any qdel stuff at the very end, with src being the very last thing
+			visible_message("[src] falls apart, the final components having been removed.")
+			qdel(S1)
+			qdel(S2)
+			qdel(S3)
+			qdel(S4)
+			qdel(src)
 
 /obj/structure/car/rubbish1
 	name = "pre-War rubbish"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes bug 19 "Interrupting welding an automobile wreck makes the wreck no longer weldable"
slight changes to salvaging the car itself
adds a var to atoms that if they have it, if they are attacked, itll attack the parent as well
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fixes are needed.
more "interactive" and "immersive."
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: salvaging cars now have a chance to drop 3-7 metal instead of only 5.
tweak: you still take 30 seconds to salvage a car, but its broken into 3 stages now instead of 1.
fix: fixed a bug where moving away from the car would render it not salvage-able.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
