### PR TITLE
glowing ghouls are now more of a problem

### DIFF
--- a/code/datums/components/glow_heal.dm
+++ b/code/datums/components/glow_heal.dm
@@ -1,0 +1,43 @@
+//I tried hard to make it for any living thing, but really, its better for only simple animals, sorry
+/datum/component/glow_heal
+	//this is the var to choose what is healed over time when the parent is alive
+	var/mob/living/simple_animal/sa_targets
+	//because I need this for some reason(?)
+	var/mob/living/simple_animal/sa_owner
+	//this is to make sure it doesnt get ridiculous
+	var/time_cooldown = 0
+	//this is the cooldown time
+	var/actual_cooldown = 5 SECONDS
+	//perhaps someone wants to make a healing effect smaller/larger(?)
+	var/heal_range = 3
+
+/datum/component/glow_heal/Initialize(mob/living/simple_animal/chosen_targets)
+	if(!isanimal(parent))
+		return COMPONENT_INCOMPATIBLE
+	sa_owner = parent
+	if(chosen_targets)
+		sa_targets = chosen_targets
+	START_PROCESSING(SSobj, src)
+	RegisterSignal(sa_owner, COMSIG_LIVING_REVIVE, .proc/restart_process)
+
+/datum/component/glow_heal/proc/restart_process()
+	START_PROCESSING(SSobj, src)
+
+/datum/component/glow_heal/process()
+	var/mob/living/srcLive = sa_owner
+	if(srcLive.stat == DEAD)
+		STOP_PROCESSING(SSobj, src)
+		return //cmon, only living things are allowed use this process
+	if(!sa_targets)
+		return //we don't need to go on cooldown if we have no targets, so keep checking
+	if(time_cooldown > world.time)
+		return //honestly need a cooldown on the healing, it could make combat really hard against a horde of ghouls
+	time_cooldown = world.time + actual_cooldown
+	for(var/mob/living/simple_animal/saMob in range(heal_range, sa_owner))
+		if(!istype(saMob, sa_targets))
+			continue
+		saMob.adjustHealth(-saMob.maxHealth*0.1)
+		if(saMob.stat == DEAD)
+			saMob.revive(full_heal = TRUE)
+		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(saMob)) //shameless copy from blobbernaut
+		H.color = "#d9ff00" //I want yellow because glowing

--- a/code/modules/mob/living/simple_animal/hostile/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ghoul.dm
@@ -118,6 +118,7 @@
 /mob/living/simple_animal/hostile/ghoul/glowing/Initialize()
 	. = ..()
 	set_light(2)
+	AddComponent(/datum/component/glow_heal, chosen_targets = /mob/living/simple_animal/hostile/ghoul)
 
 /mob/living/simple_animal/hostile/ghoul/glowing/Aggro()
 	..()
@@ -171,6 +172,7 @@
 
 /mob/living/simple_animal/hostile/ghoul/hot/Initialize()
 	. = ..()
+	AddComponent(/datum/component/glow_heal, chosen_targets = /mob/living/simple_animal/hostile/ghoul)
 
 /mob/living/simple_animal/hostile/ghoul/hot/Aggro()
 	..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -443,6 +443,7 @@
 #include "code\datums\components\field_of_vision.dm"
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\fried.dm"
+#include "code\datums\components\glow_heal.dm"
 #include "code\datums\components\gps.dm"
 #include "code\datums\components\honkspam.dm"
 #include "code\datums\components\identification.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
added a glow heal component, which could be added to any simple animal mob
the component heals the specified target type, and even revives the targets if they are dead

added the glow heal component to glowing feral ghouls, so make sure to kill them fast before an army arrives.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
brings the "Glowing One" more into its power from FO3 and beyond.
part of roleplay is having the difficult experiences that you can tell, this is one of those difficult experiences.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: glowing ghouls now will heal and even revive nearby ghouls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
