### PR TITLE
less rough monster wave, "Ride the monster wave"

### DIFF
--- a/code/controllers/subsystem/monster_wave.dm
+++ b/code/controllers/subsystem/monster_wave.dm
@@ -1,19 +1,38 @@
 SUBSYSTEM_DEF(monster_wave)
 	name = "Monster Wave"
 	wait = 1 HOURS //change to either 30 MINUTES or 1 HOURS
+	var/successful_firing = 0
+	var/allowed_firings = 2
+	var/chance_of_fire = 50
+
+//So admins, you want to be a tough guy, like it really rough guy?
+//just know you can't modify the time in between each fire
+//but you can allow it to always fire, by changing chance_of_fire to 0
+//and changing allowed_firings to like.... 12? 
 
 /datum/controller/subsystem/monster_wave/fire(resumed = 0)
 	if(times_fired <= 0)
 		message_admins("The Monster Wave has fired the first time. Next fire (in an hour) will spawn a monster pit.")
 		log_game("The Monster Wave has fired the first time. Next fire (in an hour) will spawn a monster pit.")
 		return
+	if(successful_firing >= allowed_firings)
+		message_admins("The Monster Wave has been disabled, maximum amount of waves spawned.")
+		log_game("The Monster Wave has been disabled, maximum amount of waves spawned.")
+		can_fire = FALSE
+		return
+	if(prob(chance_of_fire))
+		return // 50/50 chance for it to either fire or not fire
+	successful_firing++
+	addtimer(CALLBACK(src, .proc/spawn_monsterwave), 10 SECONDS)
+	priority_announce("WARNING: A large amount of monster activity has been detected. It is estimated that the monsters will breach the ground in a few moments. Please report the location of the breach once found.", "Monster Alert", sender_override = "Monster Reporting Division")
+
+/datum/controller/subsystem/monster_wave/proc/spawn_monsterwave()
 	var/pick_unfortune = pick("Ghoul", "Deathclaw")
 	switch(pick_unfortune)
 		if("Ghoul")
 			ghoul_wave()
 		if("Deathclaw")
 			deathclaw_wave()
-	priority_announce("WARNING: A large amount of monster activity has been detected, please report the location of activity once found.", "Monster Alert", sender_override = "Monster Reporting Division")
 
 /datum/controller/subsystem/monster_wave/proc/ghoul_wave()
 	var/spawn_amount = CEILING(GLOB.player_list.len / 5, 1)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -167,7 +167,7 @@
 			continue
 		if(locate(/obj/machinery) in F.contents)
 			continue
-		if(locate(/mob/living/carbon/human) in range(7, F))
+		if(locate(/mob/living/carbon/human) in range(12, F))
 			continue
 		return F
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the monster wave can now only run two successful times
each hour, the monster wave has a 50 percent chance to run
will announce 10 seconds prior to monster spawning
spawned monsters will be at least 12 turfs away from the nearest human

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less oppressive RNG mechanic
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked the monster wave to be less oppressive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
