### PR TITLE
the three fo13 arrows are now special

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -35,20 +35,37 @@
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/ap
 
+/obj/item/projectile/bullet/reusable/arrow/ap/on_hit(atom/target, blocked)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/targetHuman = target
+		targetHuman.adjustStaminaLoss(25) //I imagine getting hit by one of these would really, REALLY, sting; actual damage and stamina damage
+
 /obj/item/projectile/bullet/reusable/arrow/poison
 	name = "poison arrow"
 	desc = "A simple arrow, tipped in a poisonous paste."
-	damage = 35
+	damage = 10 //really gotta balance this, holy cow
 	armour_penetration = 5
-	damage_type = TOX
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/poison
+
+/obj/item/projectile/bullet/reusable/arrow/poison/on_hit(atom/target, blocked)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/targetHuman = target
+		targetHuman.reagents.add_reagent(/datum/reagent/toxin, 10) //so you get some toxin damage! around 30
 
 /obj/item/projectile/bullet/reusable/arrow/burning
 	name = "burn arrow"
 	desc = "A sumple arrow slathered in a paste that burns skin on contact."
-	damage = 35
+	damage = 10 //gotta balance it!
 	armour_penetration = 5
-	damage_type = BURN
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/burning
+
+/obj/item/projectile/bullet/reusable/arrow/burning/on_hit(atom/target, blocked)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/targetHuman = target
+		targetHuman.adjust_fire_stacks(5)
+		targetHuman.IgniteMob() //you just got burned!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ap arrows do a bit of stamina damage, since they are heavy hitters and should knock the wind out of the target without knocking them down (balance concern if it actually knocked them down or stunned them)
poison arrows don't do a lot of initial damage, but instead give 10u of toxin, which comes to around the same amount of damage, but as a dot.
fire arrows don't do a lot of initial damage, but instead light the mob on fire, which can be put out easily if they resist and "stop, drop, and roll." It easily though can be a high damage if they don't deal with it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
c o m b a t.
calling the arrows something and not actually doing what you think is disappointing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: poison arrows poison, fire arrows burn, and ap arrows hurt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
