### PR TITLE
stop sprinting when you run out of buffer, recover slower

### DIFF
--- a/code/modules/mob/living/carbon/carbon_sprint.dm
+++ b/code/modules/mob/living/carbon/carbon_sprint.dm
@@ -8,12 +8,15 @@
 	update_hud_sprint_bar()
 	if(!tiles)		//we had enough, we're done!
 		return
+	disable_intentional_sprint_mode()
+	/* stop sprint
 	var/datum/keybinding/living/toggle_sprint/sprint_bind = GLOB.keybindings_by_name["toggle_sprint"]
 	var/datum/keybinding/living/hold_sprint/sprint_hold_bind = GLOB.keybindings_by_name["hold_sprint"]
 	if(!client || !((client in sprint_bind.is_down) || (client in sprint_hold_bind.is_down))) // there are two keybinds, apparently
 		disable_intentional_sprint_mode()
 		return // if you're not holding it, you stop sprinting when you run out
 	adjustStaminaLoss(tiles * sprint_stamina_cost)		//use stamina to cover deficit.
+	*/
 
 /mob/living/carbon/proc/doSprintBufferRegen(updating = TRUE)
 	var/diff = world.time - sprint_buffer_regen_last

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -154,7 +154,7 @@
 	//Sprint buffer---
 	var/sprint_buffer = 42					//Tiles
 	var/sprint_buffer_max = 42
-	var/sprint_buffer_regen_ds = 0.3		//Tiles per world.time decisecond
+	var/sprint_buffer_regen_ds = 0.1		//Tiles per world.time decisecond
 	var/sprint_buffer_regen_last = 0		//last world.time this was regen'd for math.
 	var/sprint_stamina_cost = 0.70			//stamina loss per tile while insufficient sprint buffer.
 	//---End


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
slow combat means better escalation, slow movement relates to slow combat
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: recover sprint buffer slower
tweak: stop sprinting when buffer is emptied
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
