### PR TITLE
More oasis clinic changes and sewer changes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -13343,7 +13343,6 @@
 /area/f13/ncr)
 "kin" = (
 /obj/structure/closet,
-/obj/item/storage/box/gloves,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2948,11 +2948,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jV" = (
+/obj/item/defibrillator/loaded,
+/obj/item/storage/box/syringes,
+/obj/item/cane,
+/obj/item/soap,
+/obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/twenty,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/defibrillator/loaded,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/gloves,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jW" = (
@@ -3886,14 +3893,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "mN" = (
-/obj/item/defibrillator/loaded,
-/obj/item/storage/box/syringes,
-/obj/item/cane,
-/obj/item/soap,
-/obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/defibrillator/loaded,
-/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/twenty,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mO" = (
@@ -4760,6 +4764,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
 /obj/item/fermichem/pHmeter,
+/obj/item/storage/bag/chemistry,
 /obj/item/fermichem/pHmeter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -5460,11 +5465,8 @@
 "sm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
-/obj/item/storage/box/syringes,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/item/flashlight/pen,
 /obj/item/clothing/mask/gas,
-/obj/item/storage/box/pillbottles,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -6160,6 +6162,7 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/flashlight/pen,
+/obj/item/flashlight/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uM" = (
@@ -6207,9 +6210,27 @@
 	},
 /area/f13/bunker)
 "uV" = (
-/obj/structure/curtain{
-	open = 0
-	},
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/effect/turf_decal/box/white,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/pill_bottle/mannitol,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uW" = (
@@ -6501,8 +6522,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
+/obj/structure/curtain{
+	open = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vR" = (
@@ -8984,7 +9006,7 @@
 /area/f13/caves)
 "En" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Eo" = (
@@ -9286,14 +9308,8 @@
 	},
 /area/f13/bunker)
 "Fo" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/backpack/duffelbag/med,
-/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
-	desc = "A faded award from long ago";
-	name = "\"excellence in medicine\" award"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Fp" = (
@@ -9326,10 +9342,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "Fv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/wiki/cit/chemistry,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/circuitry,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/backpack/duffelbag/med,
+/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
+	desc = "A faded award from long ago";
+	name = "faded medical award"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Fw" = (
@@ -9902,7 +9922,10 @@
 	},
 /area/f13/tunnel)
 "HB" = (
-/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/cit/chemistry,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/circuitry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "HC" = (
@@ -11312,7 +11335,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "Mn" = (
-/obj/structure/bed/roller,
+/obj/structure/closet/crate/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Mo" = (
@@ -13028,8 +13051,6 @@
 /obj/item/storage/box/syringes,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/storage/belt/medical,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/bag/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "RM" = (
@@ -14001,6 +14022,10 @@
 	},
 /turf/open/floor/plating,
 /area/f13/brotherhood)
+"UG" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "UH" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -14209,31 +14234,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"Vm" = (
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/effect/turf_decal/box/white,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/storage/pill_bottle/chem_tin/fixer,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "Vn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -31736,7 +31736,7 @@ XP
 uL
 Hl
 Hl
-mN
+Hl
 Bs
 pX
 hd
@@ -31993,7 +31993,7 @@ aZ
 CB
 xy
 Hl
-Vm
+Pe
 Bs
 EL
 dU
@@ -32250,7 +32250,7 @@ Lx
 Lx
 Hl
 Hl
-Hl
+jV
 Bs
 Mu
 Bs
@@ -32507,11 +32507,11 @@ Lx
 Hl
 Lx
 Hl
-Hl
+uV
 Bs
-vQ
-Fo
-HB
+En
+Fv
+Mn
 Mu
 bD
 ku
@@ -32765,7 +32765,7 @@ sm
 of
 Lx
 Hl
-uV
+vQ
 Lx
 Lx
 Hl
@@ -33023,9 +33023,9 @@ Bs
 re
 Bs
 Bs
-En
-Fv
-Mn
+Fo
+HB
+UG
 Bs
 bD
 ku
@@ -33532,7 +33532,7 @@ Uv
 ia
 Lx
 Hl
-jV
+mN
 Bs
 dq
 La

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -942,8 +942,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dq" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/box/white,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "clinicladder"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dr" = (
@@ -1134,12 +1137,18 @@
 	},
 /area/f13/tunnel)
 "dW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
 	},
-/obj/structure/bed,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/tunnel)
 "dX" = (
 /obj/structure/disposalpipe/segment{
@@ -2142,15 +2151,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "hk" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
+/obj/structure/decoration/vent{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -2357,12 +2370,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hV" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "124"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hW" = (
 /obj/item/storage/trash_stack{
 	layer = 2
@@ -2409,6 +2419,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/chem_pile{
 	pixel_x = -19
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
@@ -2935,15 +2948,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jV" = (
-/obj/structure/closet/crate/medical,
-/obj/item/defibrillator/loaded,
-/obj/item/storage/box/syringes,
-/obj/item/cane,
-/obj/item/soap,
-/obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/item/defibrillator/loaded,
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/twenty,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jW" = (
@@ -3352,7 +3361,8 @@
 	},
 /area/f13/tunnel)
 "ll" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lm" = (
@@ -3876,15 +3886,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "mN" = (
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/medspray/styptic,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/silver_sulf,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/medspray/synthflesh,
-/obj/structure/closet/crate/medical,
+/obj/item/defibrillator/loaded,
+/obj/item/storage/box/syringes,
+/obj/item/cane,
+/obj/item/soap,
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/loaded,
+/obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mO" = (
@@ -3907,14 +3916,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mS" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicstorage";
-	name = "storage shutters"
-	},
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mT" = (
@@ -4290,9 +4292,13 @@
 	},
 /area/f13/tunnel)
 "of" = (
-/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/button/door{
+	id = "clinicstorage";
+	name = "shutters button";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "og" = (
 /obj/structure/bed/mattress{
@@ -5103,7 +5109,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "re" = (
-/obj/structure/dresser,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "clinicstorage";
+	name = "storage shutters"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rg" = (
@@ -5858,7 +5871,9 @@
 	},
 /area/f13/tunnel)
 "tJ" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tK" = (
@@ -6055,22 +6070,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ux" = (
-/obj/structure/decoration/vent{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uy" = (
 /obj/structure/table/reinforced,
@@ -6092,10 +6093,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/twenty,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uC" = (
@@ -6207,13 +6207,9 @@
 	},
 /area/f13/bunker)
 "uV" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/structure/closet/crate/medical,
-/obj/effect/turf_decal/box/white,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	open = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uW" = (
@@ -6506,7 +6502,7 @@
 /area/f13/tunnel)
 "vQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vR" = (
@@ -7808,8 +7804,7 @@
 	},
 /area/f13/brotherhood)
 "Al" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "An" = (
@@ -8988,10 +8983,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "En" = (
-/obj/structure/table/wood,
-/obj/item/chair/wood/modern,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "Eo" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -9291,10 +9286,13 @@
 	},
 /area/f13/bunker)
 "Fo" = (
-/obj/machinery/chem_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/backpack/duffelbag/med,
+/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
+	desc = "A faded award from long ago";
+	name = "\"excellence in medicine\" award"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -9328,11 +9326,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "Fv" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/cit/chemistry,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/circuitry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "Fw" = (
 /obj/structure/closet,
 /obj/item/locked_box/misc/money/all/low,
@@ -9903,11 +9902,7 @@
 	},
 /area/f13/tunnel)
 "HB" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "clinicladder"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "HC" = (
@@ -10927,8 +10922,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
 "La" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Lb" = (
 /obj/machinery/light{
@@ -11316,12 +11312,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "Mn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "clinicstorage";
-	name = "shutters button";
-	pixel_x = 32
-	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Mo" = (
@@ -11365,10 +11356,8 @@
 /area/f13/tunnel)
 "Mu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/clothing/head/helmet/f13/tribal,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/turf/closed/wall/f13/supermart,
+/area/f13/tunnel)
 "Mv" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
@@ -13315,14 +13304,10 @@
 	},
 /area/f13/clinic)
 "SB" = (
-/obj/machinery/chem_master,
+/obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/structure/sign/poster/prewar/poster92{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -14016,14 +14001,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/brotherhood)
-"UG" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/item/storage/firstaid/ancient,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "UH" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -14233,14 +14210,28 @@
 	},
 /area/f13/clinic)
 "Vm" = (
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/structure/closet/crate/medical,
-/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
+/obj/item/storage/firstaid/ancient,
 /obj/effect/turf_decal/box/white,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/medspray/styptic,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/storage/pill_bottle/chem_tin/fixer,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Vn" = (
@@ -14581,15 +14572,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"Wy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/tunnel)
 "Wz" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -14678,12 +14660,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/tunnel)
-"WN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "WO" = (
 /obj/structure/bed,
@@ -15451,8 +15427,15 @@
 	},
 /area/f13/clinic)
 "ZB" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile{
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/structure/sign/poster/prewar/poster92{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ZC" = (
@@ -31237,7 +31220,7 @@ US
 Al
 dZ
 Lx
-ux
+Hl
 hk
 dW
 QL
@@ -31496,7 +31479,7 @@ pB
 pB
 Hl
 Hl
-re
+Hl
 Bs
 pX
 bD
@@ -31747,7 +31730,7 @@ rF
 TQ
 Bs
 SB
-Wy
+pB
 pP
 XP
 uL
@@ -31757,9 +31740,9 @@ mN
 Bs
 pX
 hd
-Fz
-Fz
-Fz
+bD
+bD
+bD
 BR
 BR
 kp
@@ -32003,7 +31986,7 @@ JR
 ig
 Xr
 Bs
-Fo
+BV
 pB
 Lx
 aZ
@@ -32014,9 +31997,9 @@ Vm
 Bs
 EL
 dU
-Fz
-ME
-ME
+bD
+bD
+bD
 Fz
 ME
 ME
@@ -32267,13 +32250,13 @@ Lx
 Lx
 Hl
 Hl
-jV
-ia
-In
-dU
-ME
-Qx
-of
+Hl
+Bs
+Mu
+Bs
+Bs
+Mu
+bD
 Qx
 vE
 Qu
@@ -32524,13 +32507,13 @@ Lx
 Hl
 Lx
 Hl
-uV
+Hl
 Bs
-In
-Fz
-Fz
-wl
-ku
+vQ
+Fo
+HB
+Mu
+bD
 ku
 wS
 GM
@@ -32779,15 +32762,15 @@ Bs
 Hl
 RJ
 sm
+of
 Lx
-Mn
-UG
-Bs
-pX
-In
-ig
-wl
-Qx
+Hl
+uV
+Lx
+Lx
+Hl
+Mu
+EL
 ku
 Qx
 Qx
@@ -33036,15 +33019,15 @@ Bs
 Ng
 Bs
 Bs
-mS
+Bs
+re
 Bs
 Bs
+En
+Fv
+Mn
 Bs
-pX
-In
-ig
-Fz
-ku
+bD
 ku
 Qx
 Qx
@@ -33292,16 +33275,16 @@ nh
 Bs
 Lx
 uB
+hV
 Bs
 Lx
-dq
 La
 Mu
-Fv
-xh
-qC
-Fz
-Fz
+Bs
+Bs
+Bs
+Bs
+bD
 ME
 ME
 ku
@@ -33548,17 +33531,17 @@ Wu
 Uv
 ia
 Lx
-vQ
+Hl
+jV
 Bs
-HB
 dq
+La
 Bs
-En
 xh
 ig
 dI
-Fz
-Fz
+bD
+bD
 Fz
 Fz
 KR
@@ -33806,11 +33789,11 @@ Uv
 Bs
 hK
 hK
+mS
 Bs
-WN
 tJ
+ux
 Bs
-pX
 pX
 In
 Rc
@@ -34067,7 +34050,7 @@ Bs
 Bs
 Bs
 Bs
-xh
+Bs
 ig
 oT
 bD
@@ -34325,7 +34308,7 @@ In
 pX
 pX
 In
-Fz
+ig
 Fz
 bD
 Fz
@@ -43307,7 +43290,7 @@ Fz
 Fz
 Fz
 Fz
-hV
+Fz
 Fz
 Fz
 Fz
@@ -43564,7 +43547,7 @@ Fz
 Fz
 Fz
 Fz
-hV
+Fz
 Fz
 Fz
 Fz
@@ -43821,7 +43804,7 @@ sS
 Fz
 Fz
 Fz
-hV
+Fz
 Fz
 Fz
 Fz

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1032,14 +1032,8 @@
 	},
 /area/f13/tunnel)
 "dE" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dF" = (
 /turf/closed/indestructible/rock,
@@ -2276,6 +2270,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"hD" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hE" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -2370,7 +2368,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hV" = (
-/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/twenty,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hW" = (
@@ -2379,6 +2381,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "ia" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
@@ -2600,6 +2607,11 @@
 	icon_state = "grass2"
 	},
 /area/f13/brotherhood)
+"iJ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iK" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
@@ -3893,11 +3905,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "mN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/twenty,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mO" = (
@@ -3920,7 +3928,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mS" = (
-/obj/machinery/smartfridge/organ,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "clinicstorage";
+	name = "shutters button";
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mT" = (
@@ -4296,11 +4309,13 @@
 	},
 /area/f13/tunnel)
 "of" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
+/obj/machinery/door/airlock/medical{
+	name = "Clinic";
+	req_one_access_txt = "133"
+	},
+/obj/machinery/door/poddoor/shutters{
 	id = "clinicstorage";
-	name = "shutters button";
-	pixel_x = 32
+	name = "storage shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -5114,14 +5129,7 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "re" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "133"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "clinicstorage";
-	name = "storage shutters"
-	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rg" = (
@@ -5483,11 +5491,11 @@
 	},
 /area/f13/tunnel)
 "so" = (
-/obj/machinery/light/fo13colored/Pink{
-	dir = 8;
-	name = "light tube"
+/obj/structure/booth{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/locked_box/misc/resource,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "sp" = (
@@ -6072,7 +6080,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ux" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/structure/curtain{
+	open = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uy" = (
@@ -6334,13 +6344,9 @@
 	},
 /area/f13/sewer)
 "vp" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
 /obj/structure/chair/booth{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "vq" = (
@@ -6522,9 +6528,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vQ" = (
-/obj/structure/curtain{
-	open = 0
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vR" = (
@@ -7116,6 +7121,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"xL" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xM" = (
 /obj/structure/toilet{
 	dir = 4
@@ -8001,7 +8010,7 @@
 /area/f13/brotherhood)
 "AS" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
+/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "AU" = (
@@ -8495,11 +8504,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "CG" = (
-/obj/structure/booth{
-	dir = 1
-	},
+/obj/structure/booth,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/resource,
+/obj/item/locked_box/misc/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "CH" = (
@@ -9005,8 +9012,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "En" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/backpack/duffelbag/med,
+/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
+	desc = "A faded award from long ago";
+	name = "faded medical award"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Eo" = (
@@ -9309,7 +9322,7 @@
 /area/f13/bunker)
 "Fo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/ash/crematorium,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Fp" = (
@@ -9342,14 +9355,10 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "Fv" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/backpack/duffelbag/med,
-/obj/item/clothing/accessory/medal/ribbon/medical_doctor{
-	desc = "A faded award from long ago";
-	name = "faded medical award"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/cit/chemistry,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/circuitry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Fw" = (
@@ -9525,10 +9534,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Gb" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "Gd" = (
 /obj/structure/chair/wood/modern{
@@ -9922,10 +9929,7 @@
 	},
 /area/f13/tunnel)
 "HB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/wiki/cit/chemistry,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/circuitry,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "HC" = (
@@ -10268,12 +10272,8 @@
 	},
 /area/f13/clinic)
 "IL" = (
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
+/turf/closed/wall/rust,
+/area/space)
 "IM" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -11335,8 +11335,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "Mn" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "Mo" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -12105,6 +12111,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"OA" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "OB" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -12492,10 +12502,14 @@
 	},
 /area/f13/followers)
 "PQ" = (
-/obj/structure/booth,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/crafting,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/decoration/warning{
+	pixel_y = -2
+	},
+/obj/structure/sign/warning{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "PR" = (
 /mob/living/simple_animal/hostile/supermutant,
@@ -13171,15 +13185,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Se" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "Sf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14023,7 +14031,8 @@
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "UG" = (
-/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "UH" = (
@@ -14234,6 +14243,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"Vm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "Vn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -14572,6 +14586,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"Wy" = (
+/obj/structure/girder,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/tunnel)
 "Wz" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -14660,6 +14680,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
+/area/f13/tunnel)
+"WN" = (
+/obj/structure/sign/warning{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/structure/decoration/warning{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/structure/decoration/warning{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "WO" = (
 /obj/structure/bed,
@@ -25842,14 +25877,14 @@ ug
 ug
 Za
 Za
-dE
-Aw
-Aw
+ug
+ug
+ug
 oB
 WC
 WC
 WC
-Se
+WC
 xP
 MA
 "}
@@ -32509,9 +32544,9 @@ Lx
 Hl
 uV
 Bs
+vQ
 En
-Fv
-Mn
+Gb
 Mu
 bD
 ku
@@ -32762,12 +32797,12 @@ Bs
 Hl
 RJ
 sm
-of
+mS
 Lx
 Hl
-vQ
+ux
 Lx
-Lx
+Fo
 Hl
 Mu
 EL
@@ -33020,12 +33055,12 @@ Ng
 Bs
 Bs
 Bs
-re
+of
 Bs
 Bs
-Fo
+AS
+Fv
 HB
-UG
 Bs
 bD
 ku
@@ -33275,7 +33310,7 @@ nh
 Bs
 Lx
 uB
-hV
+dE
 Bs
 Lx
 La
@@ -33532,7 +33567,7 @@ Uv
 ia
 Lx
 Hl
-mN
+hV
 Bs
 dq
 La
@@ -33789,10 +33824,10 @@ Uv
 Bs
 hK
 hK
-mS
+mN
 Bs
 tJ
-ux
+re
 Bs
 pX
 In
@@ -38947,7 +38982,7 @@ Rs
 Aw
 Ry
 zJ
-Ry
+Wy
 Uu
 ug
 ug
@@ -39193,19 +39228,19 @@ QC
 QC
 QC
 QC
-ez
+nC
+QC
 QC
 QC
 QC
 QC
 QC
 IL
-IL
-IL
 QC
-lq
-lq
-lq
+QC
+PQ
+WN
+QC
 Us
 QC
 QC
@@ -39457,7 +39492,7 @@ Fz
 Fz
 QC
 Jq
-PQ
+ah
 CG
 so
 wl
@@ -39714,11 +39749,11 @@ Fz
 Fz
 QC
 Jq
-Gb
+ah
 vp
-wl
-wl
-Vn
+Mn
+Se
+iJ
 Vn
 Vn
 Tu
@@ -40230,13 +40265,13 @@ QC
 dB
 wl
 wl
-AS
 Lx
+UG
 bv
 Hl
 GA
 bw
-Vn
+hY
 QC
 Fz
 sS
@@ -40745,7 +40780,7 @@ qT
 AP
 Lx
 Lx
-Vn
+Vm
 Jq
 QC
 pB
@@ -41779,7 +41814,7 @@ wo
 PJ
 bD
 Fz
-bD
+xL
 Fz
 Fz
 Fz
@@ -42032,7 +42067,7 @@ sS
 Fz
 MA
 Fz
-bD
+hD
 bD
 PJ
 bD
@@ -42291,7 +42326,7 @@ MA
 Fz
 Fz
 bD
-bD
+OA
 bD
 Av
 Fz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a small room to the oasis clinic and other small changes. The ghouls spawning on the left part of the oasis sewers have been removed and the ones on the right have been changed to not aggro on people in the sewers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The oasis doctor now has an old storage room converted into a place to nap during long shifts. Using Risquu's new pre-anchored medical crates the stored items have been condensed into two crates. The chemical area has been rejiggered to have all stations accessible from one spot and a workbench has been added to make the chems that require it. The sewer changes A. make it so mobs no longer block matrix access and b. Now we also have a small reward for clearing the ghouls on the right side of the oasis sewers. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New area for the doctor to sleep, workbench. Random gun and t3 armor added to eastern ghoul nest. Added 2 glowing ones to bump up difficulty
tweak: crates and the location of certain work stations have been changed. Fiddled with ghoul spawns in oasis sewer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
