### PR TITLE
Remove fake space/pit floor tiles from arcade rewards

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -52,8 +52,8 @@
 		/obj/item/storage/box/fakesyndiesuit = ARCADE_WEIGHT_TRICK,
 		/obj/item/storage/crayons = ARCADE_WEIGHT_USELESS,
 		/obj/item/coin/antagtoken = ARCADE_WEIGHT_USELESS,
-		/obj/item/stack/tile/fakespace/loaded = ARCADE_WEIGHT_TRICK,
-		/obj/item/stack/tile/fakepit/loaded = ARCADE_WEIGHT_TRICK,
+//		/obj/item/stack/tile/fakespace/loaded = ARCADE_WEIGHT_TRICK,
+//		/obj/item/stack/tile/fakepit/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/restraints/handcuffs/fake = ARCADE_WEIGHT_TRICK,
 		/obj/item/clothing/gloves/fingerless/pugilist/hug = ARCADE_WEIGHT_TRICK,
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -27,7 +27,7 @@
 		/obj/item/toy/minimeteor = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/nuke = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/redbutton = ARCADE_WEIGHT_TRICK,
-		/obj/item/toy/spinningtoy = ARCADE_WEIGHT_TRICK,
+//		/obj/item/toy/spinningtoy = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword/cx = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/talking/AI = ARCADE_WEIGHT_USELESS,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I hate those floor tiles.

Edit: The little spinning singularity can get gone too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These floor tiles are not suitable for the atmosphere of our server
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Singularity toy, Fake space and fake pit floor tiles from arcade machine rewards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
