### PR TITLE
Movement tweaks and I missed a legendary raider

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -278,16 +278,16 @@
 	M.sync()
 
 /datum/config_entry/number/movedelay/sprint_speed_increase
-	config_entry_value = 1
+	config_entry_value = 0.9
 
 /datum/config_entry/number/movedelay/sprint_buffer_max
-	config_entry_value = 12
+	config_entry_value = 16
 
 /datum/config_entry/number/movedelay/sprint_stamina_cost
 	config_entry_value = 1.4
 
 /datum/config_entry/number/movedelay/sprint_buffer_regen_per_ds
-	config_entry_value = 0.2
+	config_entry_value = 0.18
 
 /////////////////////////////////////////////////Outdated move delay
 /datum/config_entry/number/outdated_movedelay

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -72,6 +72,15 @@
 	projectiletype = /obj/item/projectile/bullet/c9mm
 	projectilesound = 'sound/f13weapons/ninemil.ogg'
 
+/mob/living/simple_animal/hostile/raider/legendary
+	loot = list(/obj/effect/mob_spawn/human/corpse/raiderranged, /obj/item/kitchen/knife/combat/survival, /obj/item/reagent_containers/food/snacks/kebab/human)
+	name = "Legendary Raider"
+	desc = "Another murderer churned out by the wastes - this one seems a bit faster than the average..."
+	color = "#FFFF00"
+	maxHealth = 450
+	health = 450
+	speed = 1.2
+
 /mob/living/simple_animal/hostile/raider/ranged/legendary
 	name = "Legendary Raider"
 	desc = "Another murderer churned out by the wastes, wielding a decent pistol and looking very strong"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -32,8 +32,8 @@ OOC_DURING_ROUND
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 2
-WALK_DELAY 4
+RUN_DELAY 1.8
+WALK_DELAY 2.8
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.


### PR DESCRIPTION

## About The Pull Request
Made some slight movement speed tweaks to respond to feed back that it felt a little too slow. Walk speed is now significantly faster to encourage people to potentially walk places instead of run places. Sprint buffer has been increased but the regeneration rate decreased.

I accidentally only added one of the two types of legendary raiders not realising there was two types, so I'm bundling in the other type of legendary raider with this. This is again a copy paste from legacy.

## Why It's Good For The Game

Fingers crossed to be honest. Movement speed is very subjective. Some people felt the speeds were perfect, some too slow, trying to strike a compromise by making things just a little bit faster but not crazily so.

Walking was way too slow before however, leading to no one to ever walk.

## Changelog
:cl:
add: Melee legendary raiders
balance: Run delay: 2 -> 1.8
balance: Walk delay: 4 -> 2.8
balance: Sprint speed increase: 1 -> 0.9
balance: Sprint buffer 12 -> 16
balance: Sprint buffer regen per second: 2 -> 1.8
/:cl:
