### PR TITLE
Rename oasis forge and add metal

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1807,6 +1807,14 @@
 /obj/structure/rack,
 /turf/open/floor/plating/f13,
 /area/f13/followers)
+"gm" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Town Forge";
+	req_one_access_txt = "25"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gn" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -2996,14 +3004,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/tunnel)
-"ka" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Public Forge";
-	req_one_access_txt = "25"
-	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kb" = (
 /obj/item/pet_carrier,
@@ -11756,6 +11756,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"Nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/wood,
+/area/f13/tunnel)
 "Ny" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
@@ -13382,12 +13388,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"SI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/wood,
-/area/f13/tunnel)
 "SJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -28446,7 +28446,7 @@ qT
 rA
 mH
 sI
-SI
+Nx
 mH
 Ms
 BR
@@ -28698,7 +28698,7 @@ Fz
 EL
 bD
 ps
-ka
+gm
 qT
 qT
 qT

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -103,6 +103,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"at" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/wood,
+/area/f13/tunnel)
 "au" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -2385,6 +2391,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
+/area/f13/tunnel)
+"hZ" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Public Forge";
+	req_one_access_txt = "25"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ia" = (
 /obj/structure/decoration/vent/rusty,
@@ -28432,7 +28446,7 @@ qT
 rA
 mH
 sI
-sI
+at
 mH
 Ms
 BR
@@ -28684,7 +28698,7 @@ Fz
 EL
 bD
 ps
-KT
+hZ
 qT
 qT
 qT

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -103,12 +103,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"at" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/wood,
-/area/f13/tunnel)
 "au" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -2391,14 +2385,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
-/area/f13/tunnel)
-"hZ" = (
-/obj/machinery/door/unpowered/wooddoor{
-	autoclose = 1;
-	name = "Public Forge";
-	req_one_access_txt = "25"
-	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ia" = (
 /obj/structure/decoration/vent/rusty,
@@ -28446,7 +28432,7 @@ qT
 rA
 mH
 sI
-at
+sI
 mH
 Ms
 BR
@@ -28698,7 +28684,7 @@ Fz
 EL
 bD
 ps
-hZ
+KT
 qT
 qT
 qT

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2997,6 +2997,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"ka" = (
+/obj/machinery/door/unpowered/wooddoor{
+	autoclose = 1;
+	name = "Public Forge";
+	req_one_access_txt = "25"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kb" = (
 /obj/item/pet_carrier,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -13374,6 +13382,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"SI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/wood,
+/area/f13/tunnel)
 "SJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -28432,7 +28446,7 @@ qT
 rA
 mH
 sI
-sI
+SI
 mH
 Ms
 BR
@@ -28684,7 +28698,7 @@ Fz
 EL
 bD
 ps
-KT
+ka
 qT
 qT
 qT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change forge name. Adds metal
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Citizens often try to lock up the town forge and make it into a house because it's labeled "public housing". This fixes that. With lockpicks becoming such an important implementation it also makes sense to increase the metal available to the town. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more metal to forge
tweak: Changed forge door name to "Town Forge"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
